### PR TITLE
update gemspec -> description typo fix + add rake development dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .rspec_status
 *.gem
+
+# Gemfile.lock
+*.lock

--- a/parse-http.gemspec
+++ b/parse-http.gemspec
@@ -7,16 +7,19 @@ Gem::Specification.new do |spec|
   spec.email         = ['ademdinarevic@gmail.com']
   spec.homepage      = 'https://github.com/ademdc/parse-http'
   spec.license       = 'MIT'
-  spec.summary       = "Ruby client for Etsy API"
-  spec.description   = "Ruby client for Etsy API"
+  spec.summary       = "HTTP parser for Ruby"
+  spec.description   = "HTTP parser for Ruby"
   spec.require_paths = ['lib']
+  spec.bindir        = ['bin']
+
   
   spec.files         =  %w[
     lib/http-parser.rb
     lib/http-parser/version.rb
   ]
 
-  spec.required_ruby_version = '>= 2.5.8'
+  spec.required_ruby_version = '>= 2.6.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rake', '~> 13.0.3'
 
 end


### PR DESCRIPTION
Gemspec contained `summary` and `description` from your another Gem - `RubyEtsy`, so I changed it to this one from http-parser repository. Pretty usual mistake in Ruby :) Rake is added as development dependency, and `Gemfile.lock` is added to `.gitignore'

Pozdrav!